### PR TITLE
Add how to build specific version

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -88,6 +88,16 @@ cd "$dir"
 go install ./cmd/swagger
 ```
 
+To install a specific version from source an appropriate tag needs to be checked out first (e.g. `v0.25.0`). Also to make `swagger version` command print the version and commit info additional `-ldflags` need to be specified:
+
+```
+dir=$(mktemp -d)
+git clone https://github.com/go-swagger/go-swagger "$dir" 
+cd "$dir"
+go checkout v0.25.0
+go install -ldflags "-X github.com/go-swagger/go-swagger/cmd/swagger/commands.Version=$(git describe --tags) -X github.com/go-swagger/go-swagger/cmd/swagger/commands.Commit=$(git rev-parse HEAD)" ./cmd/swagger
+```
+
 You are welcome to clone this repo and start contributing:
 ```
 git clone https://github.com/go-swagger/go-swagger


### PR DESCRIPTION
There's no information in documentation how to build a specific version of `go-swagger` from source. I looked into it some time ago when my specific tag checkout build was showing `version` as `dev`. Today someone asked on [Stack Overflow](https://stackoverflow.com/questions/65606224/replace-go-swagger-with-another-version-in-windows/65606380?noredirect=1#comment116003343_65606380) so I feel it might be useful to have bit about checking out version tag as well as passing same `-ldflags` as in CircleCI in Installation from source document section.